### PR TITLE
fix(frontend): disable fingerprinting for images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,6 @@
 version: "3"
 services:
 
-  ember:
-    image: danlynn/ember-cli:latest
-    volumes:
-      - ./ember:/myapp
-      - ./ember/node_modules/:/myapp/node_modules
-    tmpfs:
-      - /myapp/tmp
-    ports:
-      - "4200:4200"
-      - "7020:7020"
-      - "7357:7357"
-    command: ember serve --proxy http://proxy
-
   proxy:
     image: nginx:1.15-alpine
     volumes:

--- a/ember/ember-cli-build.js
+++ b/ember/ember-cli-build.js
@@ -23,6 +23,11 @@ module.exports = function (defaults) {
     "ember-fetch": {
       preferNative: true,
     },
+    fingerprint: {
+      // disable fingerprinting for images to make sure logo
+      // config path doesn't break in production
+      extensions: ["js", "css", "map"],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
This makes sure that the configurable logo path doesn't break because of
fingerprinting in production.